### PR TITLE
Create HA+ node groups

### DIFF
--- a/deployments/highwind/terraform/main.tf
+++ b/deployments/highwind/terraform/main.tf
@@ -23,6 +23,47 @@ locals {
 
   kf_helm_repo_path = var.kf_helm_repo_path
 
+  managed_node_group_highwind_cpu_on_demand = {
+    node_group_name = "highwind-on-demand"
+    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    min_size        = 3
+    desired_size    = 3
+    max_size        = 3
+    disk_size       = 150 # GB var.node_disk_size_cpu
+    subnet_ids      = module.vpc.private_subnets
+  }
+
+  managed_node_group_workload_spot = {
+    node_group_name = "workload-spot"
+    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    capacity_type   = "SPOT"
+    min_size        = 2
+    desired_size    = 2
+    max_size        = 2
+    disk_size       = 150 # GB var.node_disk_size_cpu
+    subnet_ids      = module.vpc.private_subnets
+  }
+
+  managed_node_group_core_system_cpu_on_demand = {
+    node_group_name = "core-system-on-demand"
+    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    min_size        = 3
+    desired_size    = 3
+    max_size        = 3
+    disk_size       = 150 # GB var.node_disk_size_cpu
+    subnet_ids      = module.vpc.private_subnets
+  }
+
+  managed_node_group_core_system_cpu_spot = {
+    node_group_name = "core-system-on-demand"
+    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    capacity_type   = "SPOT"
+    min_size        = 2
+    desired_size    = 2
+    max_size        = 2
+    disk_size       = 150 # GB var.node_disk_size_cpu
+    subnet_ids      = module.vpc.private_subnets
+  }
 
   managed_node_group_cpu = {
     node_group_name = "managed-ondemand-cpu"
@@ -30,17 +71,6 @@ locals {
     min_size        = 4
     desired_size    = 4
     max_size        = 4
-    disk_size       = var.node_disk_size_cpu
-    subnet_ids      = module.vpc.private_subnets
-  }
-
-  managed_node_group_cpu_spot = {
-    node_group_name = "managed-spot-cpu"
-    instance_types  = [var.node_instance_type]
-    capacity_type   = "SPOT"
-    min_size        = 0
-    desired_size    = 0
-    max_size        = 1
     disk_size       = var.node_disk_size_cpu
     subnet_ids      = module.vpc.private_subnets
   }
@@ -68,11 +98,13 @@ locals {
   } : null
 
   potential_managed_node_groups = {
-    mg_cpu            = local.managed_node_group_cpu,
-    mg_gpu            = local.managed_node_group_gpu
-    mg_cpu_spot       = local.managed_node_group_cpu_spot
-    mg_cpu_mixed_spot = local.managed_node_group_cpu_mixed_spot
-
+    mg_cpu                = local.managed_node_group_cpu
+    mg_gpu                = local.managed_node_group_gpu
+    mg_cpu_mixed_spot     = local.managed_node_group_cpu_mixed_spot
+    mg_hw_on_demand       = local.managed_node_group_highwind_cpu_on_demand
+    mg_workload_spot      = local.managed_node_group_workload_spot
+    mg_core_sys_on_demand = local.managed_node_group_core_system_cpu_on_demand
+    mg_core_sys_spot      = local.managed_node_group_core_system_cpu_spot
   }
 
   managed_node_groups = { for k, v in local.potential_managed_node_groups : k => v if v != null }

--- a/deployments/highwind/terraform/main.tf
+++ b/deployments/highwind/terraform/main.tf
@@ -25,43 +25,41 @@ locals {
 
   managed_node_group_highwind_cpu_on_demand = {
     node_group_name = "highwind-on-demand"
-    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
-    min_size        = 3
-    desired_size    = 3
-    max_size        = 3
-    disk_size       = 150 # GB var.node_disk_size_cpu
+    instance_types  = var.highwind_cpu_on_demand_config.instance_types
+    min_size        = var.highwind_cpu_on_demand_config.min
+    desired_size    = var.highwind_cpu_on_demand_config.desired
+    max_size        = var.highwind_cpu_on_demand_config.max
+    disk_size       = var.highwind_cpu_on_demand_config.disk_size
     subnet_ids      = module.vpc.private_subnets
   }
 
   managed_node_group_workload_spot = {
     node_group_name = "workload-spot"
-    instance_types  = ["m5.xlarge", "m6i.xlarge", "m7i.xlarge"]
-    capacity_type   = "SPOT"
-    min_size        = 2
-    desired_size    = 2
-    max_size        = 2
-    disk_size       = 150 # GB var.node_disk_size_cpu
+    instance_types  = var.workload_spot_config.instance_types
+    min_size        = var.workload_spot_config.min
+    desired_size    = var.workload_spot_config.desired
+    max_size        = var.workload_spot_config.max
+    disk_size       = var.workload_spot_config.disk_size
     subnet_ids      = module.vpc.private_subnets
   }
 
   managed_node_group_core_system_cpu_on_demand = {
     node_group_name = "core-system-on-demand"
-    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
-    min_size        = 3
-    desired_size    = 3
-    max_size        = 3
-    disk_size       = 150 # GB var.node_disk_size_cpu
+    instance_types  = var.core_system_cpu_on_demand_config.instance_types
+    min_size        = var.core_system_cpu_on_demand_config.min
+    desired_size    = var.core_system_cpu_on_demand_config.desired
+    max_size        = var.core_system_cpu_on_demand_config.max
+    disk_size       = var.core_system_cpu_on_demand_config.disk_size
     subnet_ids      = module.vpc.private_subnets
   }
 
   managed_node_group_core_system_cpu_spot = {
     node_group_name = "core-system-on-demand"
-    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
-    capacity_type   = "SPOT"
-    min_size        = 2
-    desired_size    = 2
-    max_size        = 2
-    disk_size       = 150 # GB var.node_disk_size_cpu
+    instance_types  = var.core_system_cpu_spot_config.instance_types
+    min_size        = var.core_system_cpu_spot_config.min
+    desired_size    = var.core_system_cpu_spot_config.desired
+    max_size        = var.core_system_cpu_spot_config.max
+    disk_size       = var.core_system_cpu_spot_config.disk_size
     subnet_ids      = module.vpc.private_subnets
   }
 

--- a/deployments/highwind/terraform/main.tf
+++ b/deployments/highwind/terraform/main.tf
@@ -25,7 +25,7 @@ locals {
 
   managed_node_group_highwind_cpu_on_demand = {
     node_group_name = "highwind-on-demand"
-    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
     min_size        = 3
     desired_size    = 3
     max_size        = 3
@@ -35,7 +35,7 @@ locals {
 
   managed_node_group_workload_spot = {
     node_group_name = "workload-spot"
-    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    instance_types  = ["m5.xlarge", "m6i.xlarge", "m7i.xlarge"]
     capacity_type   = "SPOT"
     min_size        = 2
     desired_size    = 2
@@ -46,7 +46,7 @@ locals {
 
   managed_node_group_core_system_cpu_on_demand = {
     node_group_name = "core-system-on-demand"
-    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
     min_size        = 3
     desired_size    = 3
     max_size        = 3
@@ -56,7 +56,7 @@ locals {
 
   managed_node_group_core_system_cpu_spot = {
     node_group_name = "core-system-on-demand"
-    instance_types  = ["m5i.large", "m6i.large", "m7i.large"]
+    instance_types  = ["m5.large", "m6i.large", "m7i.large"]
     capacity_type   = "SPOT"
     min_size        = 2
     desired_size    = 2

--- a/deployments/highwind/terraform/main.tf
+++ b/deployments/highwind/terraform/main.tf
@@ -35,6 +35,7 @@ locals {
 
   managed_node_group_workload_spot = {
     node_group_name = "workload-spot"
+    capacity_type   = "SPOT"
     instance_types  = var.workload_spot_config.instance_types
     min_size        = var.workload_spot_config.min
     desired_size    = var.workload_spot_config.desired
@@ -55,6 +56,7 @@ locals {
 
   managed_node_group_core_system_cpu_spot = {
     node_group_name = "core-system-spot"
+    capacity_type   = "SPOT"
     instance_types  = var.core_system_cpu_spot_config.instance_types
     min_size        = var.core_system_cpu_spot_config.min
     desired_size    = var.core_system_cpu_spot_config.desired

--- a/deployments/highwind/terraform/main.tf
+++ b/deployments/highwind/terraform/main.tf
@@ -54,7 +54,7 @@ locals {
   }
 
   managed_node_group_core_system_cpu_spot = {
-    node_group_name = "core-system-on-demand"
+    node_group_name = "core-system-spot"
     instance_types  = var.core_system_cpu_spot_config.instance_types
     min_size        = var.core_system_cpu_spot_config.min
     desired_size    = var.core_system_cpu_spot_config.desired

--- a/deployments/highwind/terraform/variables.tf
+++ b/deployments/highwind/terraform/variables.tf
@@ -214,54 +214,70 @@ variable "notebook_idleness_check_period" {
   default     = 5
 }
 
-variable "highwind_cpu_on_demand_sizing" {
+variable "highwind_cpu_on_demand_config" {
   type = object({
-    min     = number
-    desired = number
-    max     = number
+    min            = number
+    desired        = number
+    max            = number
+    instance_types = string
+    disk_size      = number
   })
   default = {
-    min     = 0
-    desired = 0
-    max     = 1
+    min            = 0
+    desired        = 0
+    max            = 1
+    instance_types = ["m5.large", "m6i.large", "m7i.large"]
+    disk_size      = 150
   }
 }
 
-variable "workload_spot_sizing" {
+variable "workload_spot_config" {
   type = object({
-    min     = number
-    desired = number
-    max     = number
+    min            = number
+    desired        = number
+    max            = number
+    instance_types = string
+    disk_size      = number
   })
   default = {
-    min     = 0
-    desired = 0
-    max     = 1
+    min            = 0
+    desired        = 0
+    max            = 1
+    instance_types = ["m5.xlarge", "m6i.xlarge", "m7i.xlarge"]
+    disk_size      = 150
   }
 }
 
-variable "core_system_cpu_on_demand_sizing" {
+variable "core_system_cpu_on_demand_config" {
   type = object({
-    min     = number
-    desired = number
-    max     = number
+    min            = number
+    desired        = number
+    max            = number
+    instance_types = string
+    disk_size      = number
   })
   default = {
-    min     = 0
-    desired = 0
-    max     = 1
+    min            = 0
+    desired        = 0
+    max            = 1
+    instance_types = ["m5.large", "m6i.large", "m7i.large"]
+    disk_size      = 150
   }
 }
 
-variable "core_system_cpu_spot_sizing" {
+variable "core_system_cpu_spot_config" {
   type = object({
-    min     = number
-    desired = number
-    max     = number
+    min            = number
+    desired        = number
+    max            = number
+    instance_types = string
+    disk_size      = number
   })
   default = {
-    min     = 0
-    desired = 0
-    max     = 1
+    min            = 0
+    desired        = 0
+    max            = 1
+    instance_types = ["m5.large", "m6i.large", "m7i.large"]
+    disk_size      = 150
   }
 }

--- a/deployments/highwind/terraform/variables.tf
+++ b/deployments/highwind/terraform/variables.tf
@@ -215,6 +215,7 @@ variable "notebook_idleness_check_period" {
 }
 
 variable "highwind_cpu_on_demand_config" {
+  description = "EKS node group highwind-on-demand configuration"
   type = object({
     min            = number
     desired        = number
@@ -232,6 +233,7 @@ variable "highwind_cpu_on_demand_config" {
 }
 
 variable "workload_spot_config" {
+  description = "EKS node group workload-spot configuration"
   type = object({
     min            = number
     desired        = number
@@ -249,6 +251,7 @@ variable "workload_spot_config" {
 }
 
 variable "core_system_cpu_on_demand_config" {
+  description = "EKS node group core-system-on-demand configuration"
   type = object({
     min            = number
     desired        = number
@@ -266,6 +269,7 @@ variable "core_system_cpu_on_demand_config" {
 }
 
 variable "core_system_cpu_spot_config" {
+  description = "EKS node group core-system-spot configuration"
   type = object({
     min            = number
     desired        = number

--- a/deployments/highwind/terraform/variables.tf
+++ b/deployments/highwind/terraform/variables.tf
@@ -213,3 +213,55 @@ variable "notebook_idleness_check_period" {
   type        = string
   default     = 5
 }
+
+variable "highwind_cpu_on_demand_sizing" {
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  default = {
+    min     = 0
+    desired = 0
+    max     = 1
+  }
+}
+
+variable "workload_spot_sizing" {
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  default = {
+    min     = 0
+    desired = 0
+    max     = 1
+  }
+}
+
+variable "core_system_cpu_on_demand_sizing" {
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  default = {
+    min     = 0
+    desired = 0
+    max     = 1
+  }
+}
+
+variable "core_system_cpu_spot_sizing" {
+  type = object({
+    min     = number
+    desired = number
+    max     = number
+  })
+  default = {
+    min     = 0
+    desired = 0
+    max     = 1
+  }
+}

--- a/deployments/highwind/terraform/variables.tf
+++ b/deployments/highwind/terraform/variables.tf
@@ -228,7 +228,7 @@ variable "highwind_cpu_on_demand_config" {
     desired        = 0
     max            = 1
     instance_types = ["m5.large", "m6i.large", "m7i.large"]
-    disk_size      = 150
+    disk_size      = 150 # GB
   }
 }
 

--- a/deployments/highwind/terraform/variables.tf
+++ b/deployments/highwind/terraform/variables.tf
@@ -219,7 +219,7 @@ variable "highwind_cpu_on_demand_config" {
     min            = number
     desired        = number
     max            = number
-    instance_types = string
+    instance_types = list(string)
     disk_size      = number
   })
   default = {
@@ -236,7 +236,7 @@ variable "workload_spot_config" {
     min            = number
     desired        = number
     max            = number
-    instance_types = string
+    instance_types = list(string)
     disk_size      = number
   })
   default = {
@@ -253,7 +253,7 @@ variable "core_system_cpu_on_demand_config" {
     min            = number
     desired        = number
     max            = number
-    instance_types = string
+    instance_types = list(string)
     disk_size      = number
   })
   default = {
@@ -270,7 +270,7 @@ variable "core_system_cpu_spot_config" {
     min            = number
     desired        = number
     max            = number
-    instance_types = string
+    instance_types = list(string)
     disk_size      = number
   })
   default = {


### PR DESCRIPTION
Create the node groups according to our discussed approach. The existing scaled up node groups have been left untouched.

Approach:

1. Create and scale up the new node groups
2. Scale down existing node groups: `managed-mixed-spot-cpu` and `managed-ondemand-cpu`
3. Delete old node groups: `managed-mixed-spot-cpu` and `managed-ondemand-cpu`
4. Update the disk_size to use `var.node_disk_size_cpu` variable and set the variable in `sample.auto.tfvars`